### PR TITLE
Various fixes for exporting from linux -> windows VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,5 @@ rekordbox.xml
 ffmpeg.exe
 ffplay.exe
 ffprobe.exe
+*~
+/result

--- a/.nixignore
+++ b/.nixignore
@@ -1,0 +1,3 @@
+/.git
+/shell.nix
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, python3
+, ffmpeg-headless
+, makeWrapper
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: with ps; [
+    eyed3
+    lxml
+    protobuf
+    pydub
+    tinytag
+    tqdm
+  ]);
+in
+stdenv.mkDerivation rec {
+  pname = "mixxx-to-rekordbox";
+  version = "0.1.0-dev";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/mixxx-to-rekordbox $out/bin
+    cp -r . $out/lib/mixxx-to-rekordbox/
+
+    makeWrapper ${pythonEnv}/bin/python $out/bin/mixxx-to-rekordbox \
+      --add-flags "$out/lib/mixxx-to-rekordbox/main.py" \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg-headless ]}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Sync your Mixxx Playlists to Rekordbox XML, optionally reformatting your files";
+    homepage = "https://github.com/TheKantankerus/MixxxToRekordbox";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.bendlas ];
+    mainProgram = "mixxx-to-rekordbox";
+    platforms = lib.platforms.all;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,10 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }: let
+    forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+  in {
+    packages = forAllSystems (system: {
+      default = (import nixpkgs { inherit system; }).callPackage ./default.nix {};
+    });
+  };
+}

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -36,6 +36,9 @@ def get_track_info(
     key_type: KeyType,
     export_semaphore: Semaphore,
 ) -> tuple[TrackContext, BeatGridInfo | None]:
+    info = sql_handlers.get_track_info(track_id)
+    if info is None:
+        return None, None
     (
         samplerate,
         channels,
@@ -51,13 +54,11 @@ def get_track_info(
         rating,
         colour,
         track_location,
-    ) = sql_handlers.get_track_info(track_id)
-
+    ) = info
     if out_dir or out_format:
         track_location = change_track_location(
             track_location, out_dir, out_format, export_semaphore
         )
-
     return TrackContext(
         id=track_id,
         samplerate=int(samplerate),
@@ -105,10 +106,11 @@ def get_exported_track(
 ) -> ExportedTrack:
     if track_id in track_collection:
         return track_collection[track_id]
-
     track_context, beat_grid = get_track_info(
         track_id, out_dir, out_format, key_type, export_semaphore
     )
+    if track_context is None:
+        return None
     return ExportedTrack(
         id=format_track_id(track_id),
         track_context=track_context,
@@ -140,6 +142,7 @@ def get_data_for_tracks(
         initargs=(db_location,),
     ) as pool:
         return list(
+            el for el in
             tqdm(
                 pool.imap(
                     partial(
@@ -156,6 +159,7 @@ def get_data_for_tracks(
                 unit="track",
                 total=len(track_ids),
             )
+            if el is not None
         )
 
 

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -3,6 +3,7 @@ from multiprocessing import Manager
 from multiprocessing.pool import Pool
 from multiprocessing.synchronize import Semaphore
 from lxml import etree
+import logging
 from handlers import sql as sql_handlers
 from handlers.transcode import EXPORT_SEMAPHORE_COUNT, change_track_location
 from models import (
@@ -216,18 +217,21 @@ def export_to_rekordbox_xml(
     for collection in collections:
         collection_id = collection[0]
         collection_name = collection[1]
-        xml_element = append_collection_to_element(
-            collection_id,
-            collection_name,
-            xml_element,
-            export_all,
-            collection_type,
-            out_dir,
-            out_format,
-            key_type,
-            db_location,
-            virtual_out_dir,
-        )
+        try:
+            xml_element = append_collection_to_element(
+                collection_id,
+                collection_name,
+                xml_element,
+                export_all,
+                collection_type,
+                out_dir,
+                out_format,
+                key_type,
+                db_location,
+                virtual_out_dir,
+            )
+        except Exception as e:
+            logging.error('Error exporting playlist %s', collection_name, exc_info=e)
         flush_offset_errors()
         print("")
     with open("rekordbox.xml", "wb") as fd:

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from lxml import etree
 from tqdm import tqdm
+import logging
 
 from handlers import sql as sql_handlers
 from handlers.transcode import EXPORT_SEMAPHORE_COUNT, change_track_location
@@ -250,18 +251,21 @@ def export_to_rekordbox_xml(
     for collection in collections:
         collection_id = collection[0]
         collection_name = collection[1]
-        xml_element = append_collection_to_element(
-            collection_id,
-            collection_name,
-            xml_element,
-            export_all,
-            collection_type,
-            out_dir,
-            out_format,
-            key_type,
-            db_location,
-            virtual_out_dir,
-        )
+        try:
+            xml_element = append_collection_to_element(
+                collection_id,
+                collection_name,
+                xml_element,
+                export_all,
+                collection_type,
+                out_dir,
+                out_format,
+                key_type,
+                db_location,
+                virtual_out_dir,
+            )
+        except Exception as e:
+            logging.error('Error exporting playlist %s', collection_name, exc_info=e)
         flush_offset_errors()
         print("")
     with open("rekordbox.xml", "wb") as fd:

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -38,6 +38,7 @@ def get_track_info(
     out_format: str | None,
     key_type: KeyType,
     export_semaphore: Semaphore,
+    virtual_out_dir: str | None
 ) -> tuple[TrackContext, BeatGridInfo | None] | None:
     track_info = sql_handlers.get_track_info(track_id)
     if track_info:
@@ -59,14 +60,12 @@ def get_track_info(
         ) = track_info
     else:
         return None
-
     if not Path.exists(track_location):
         print(f"File not found at {track_location}")
         return None
-
     if out_dir or out_format:
         track_location = change_track_location(
-            track_location, out_dir, out_format, export_semaphore
+            track_location, out_dir, out_format, export_semaphore, virtual_out_dir
         )
     if track_location.endswith(".ogg"):
         temp_path = Path.home().absolute() / "temp"
@@ -130,19 +129,17 @@ def get_exported_track(
     key_type: KeyType,
     export_semaphore: Semaphore,
     track_collection: dict,
+    virtual_out_dir: str | None
 ) -> ExportedTrack | None:
     if track_id in track_collection:
         return track_collection[track_id]
-
     track_info = get_track_info(
-        track_id, out_dir, out_format, key_type, export_semaphore
+        track_id, out_dir, out_format, key_type, export_semaphore, virtual_out_dir
     )
     if not track_info:
         print(f"No info found for Track {track_id}")
         return None
-
     track_context, beat_grid = track_info
-
     if track_context is None:
         return None
 
@@ -166,6 +163,7 @@ def get_data_for_tracks(
     out_format: str | None,
     key_type: KeyType,
     db_location: str | None,
+    virtual_out_dir: str | None,
 ) -> list[ExportedTrack]:
     manager = Manager()
     export_semaphore = manager.Semaphore(EXPORT_SEMAPHORE_COUNT)
@@ -189,6 +187,7 @@ def get_data_for_tracks(
                             key_type=key_type,
                             export_semaphore=export_semaphore,
                             track_collection=track_collection,
+                            virtual_out_dir=virtual_out_dir,
                         ),
                         track_ids,
                         chunksize=1 if out_format else 2,
@@ -212,6 +211,7 @@ def append_collection_to_element(
     out_format: str | None,
     key_type: KeyType,
     db_location: str | None,
+    virtual_out_dir: str | None,
 ) -> etree.Element:
     if (
         not export_all
@@ -223,7 +223,7 @@ def append_collection_to_element(
     track_ids = sql_handlers.get_collection_tracks(collection_type, collection_id)
 
     return generate_xml(
-        get_data_for_tracks(track_ids, out_dir, out_format, key_type, db_location),
+        get_data_for_tracks(track_ids, out_dir, out_format, key_type, db_location, virtual_out_dir),
         collection_name,
         xml_element,
     )
@@ -236,6 +236,7 @@ def export_to_rekordbox_xml(
     mixxx_db_location: str | None,
     key_type: KeyType,
     collection_type: CollectionType,
+    virtual_out_dir: str | None,
 ) -> None:
     db_location = sql_handlers.get_mixxx_db_location(mixxx_db_location)
     if out_format and not out_dir:
@@ -259,6 +260,7 @@ def export_to_rekordbox_xml(
             out_format,
             key_type,
             db_location,
+            virtual_out_dir,
         )
         flush_offset_errors()
         print("")

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -10,6 +10,7 @@ import logging
 
 from handlers import sql as sql_handlers
 from handlers.transcode import EXPORT_SEMAPHORE_COUNT, change_track_location
+from list_file import parse_list_file, write_list_file
 from models import (
     RATING_MAP,
     BeatGridInfo,
@@ -23,6 +24,7 @@ from models import (
 from offset_handlers import flush_offset_errors
 from rekordbox_gen import (
     TRACK_COLLECTION,
+    create_root_element,
     encode_xml_element,
     format_track_id,
     generate_xml,
@@ -214,7 +216,6 @@ def append_collection_to_element(
     collection_id: str,
     collection_name: str,
     xml_element: etree.Element,
-    export_all: bool,
     collection_type: CollectionType,
     out_dir: str | None,
     out_format: str | None,
@@ -222,12 +223,6 @@ def append_collection_to_element(
     db_location: str | None,
     virtual_out_dir: str | None,
 ) -> etree.Element:
-    if (
-        not export_all
-        and input(f"Export {collection_name}? [y/n]").lower().strip() != "y"
-    ):
-        return xml_element
-
     print(f"{collection_name}:")
     track_ids = sql_handlers.get_collection_tracks(collection_type, collection_id)
 
@@ -244,39 +239,78 @@ def export_to_rekordbox_xml(
     export_all: bool,
     mixxx_db_location: str | None,
     key_type: KeyType,
-    collection_type: CollectionType,
+    collection_types: list[CollectionType],
     virtual_out_dir: str | None,
+    prefixes: dict[CollectionType, str],
+    suffixes: dict[CollectionType, str],
+    list_file: str | None,
+    generate_list_file: str | None,
 ) -> None:
     db_location = sql_handlers.get_mixxx_db_location(mixxx_db_location)
     if out_format and not out_dir:
         raise Exception("Output directory must be specified if changing file formats.")
     sql_handlers.set_db_location(db_location)
 
-    collections = sql_handlers.get_collections(collection_type)
+    # When asked, write a list file of every available collection (commented
+    # out) and exit without exporting anything.
+    if generate_list_file:
+        all_collections = {
+            ctype: sql_handlers.get_collections(ctype) for ctype in collection_types
+        }
+        write_list_file(generate_list_file, all_collections)
+        total = sum(len(items) for items in all_collections.values())
+        print(f"Wrote {total} collections to list file: {generate_list_file}")
+        return
 
-    print(f"Preparing to export {len(collections)} {collection_type}s...\n")
-    xml_element = None
-    for collection in collections:
-        collection_id = collection[0]
-        collection_name = collection[1]
-        try:
-            xml_element = append_collection_to_element(
-                collection_id,
-                collection_name,
-                xml_element,
-                export_all,
-                collection_type,
-                out_dir,
-                out_format,
-                key_type,
-                db_location,
-                virtual_out_dir,
-            )
-        except Exception as e:
-            logging.error('Error exporting playlist %s', collection_name, exc_info=e)
-        flush_offset_errors()
-        print("")
-    with open("rekordbox.xml", "wb") as fd:
+    # If a list file is supplied, only the non-commented entries are exported,
+    # non-interactively. Entries absent from the file are skipped entirely.
+    selected: dict[CollectionType, set[str]] | None = (
+        parse_list_file(list_file) if list_file else None
+    )
+
+    xml_element = create_root_element()
+    for collection_type in collection_types:
+        collections = sql_handlers.get_collections(collection_type)
+        prefix = prefixes.get(collection_type, "")
+        suffix = suffixes.get(collection_type, "")
+        print(f"Preparing to export {len(collections)} {collection_type}s...\n")
+        for collection in collections:
+            collection_id = collection[0]
+            collection_name = collection[1]
+
+            if selected is not None:
+                if collection_name not in selected[collection_type]:
+                    continue
+                should_export = True
+            else:
+                should_export = export_all or (
+                    input(f"Export {collection_name}? [y/n]").lower().strip() == "y"
+                )
+            if not should_export:
+                continue
+
+            export_name = f"{prefix}{collection_name}{suffix}"
+            try:
+                xml_element = append_collection_to_element(
+                    collection_id,
+                    export_name,
+                    xml_element,
+                    collection_type,
+                    out_dir,
+                    out_format,
+                    key_type,
+                    db_location,
+                    virtual_out_dir,
+                )
+            except Exception as e:
+                logging.error('Error exporting %s %s', collection_type, collection_name, exc_info=e)
+            flush_offset_errors()
+            print("")
+    # Write the XML next to the exported tracks when --out-dir is set, so the
+    # whole bundle lives in one place. Otherwise fall back to the CWD.
+    out_dir_path = Path(out_dir) if out_dir else Path(".")
+    xml_path = out_dir_path / "rekordbox.xml"
+    with open(xml_path, "wb") as fd:
         fd.write(encode_xml_element(xml_element))
         fd.close()
-    print("done")
+    print(f"done: {xml_path}")

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -64,6 +64,9 @@ def get_track_info(
     if not Path.exists(track_location):
         print(f"File not found at {track_location}")
         return None
+
+    track_source = track_location
+
     if out_dir or out_format:
         track_location = change_track_location(
             track_location, out_dir, out_format, export_semaphore, virtual_out_dir
@@ -91,6 +94,7 @@ def get_track_info(
         genre=genre or "",
         bpm=float(bpm) or 0.0,
         location=track_location,
+        source=track_source,
         key=key_type.get_key(key_id),
         rating=RATING_MAP[rating],
         colour=colour,

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -142,6 +142,10 @@ def get_exported_track(
         return None
 
     track_context, beat_grid = track_info
+
+    if track_context is None:
+        return None
+
     return ExportedTrack(
         id=format_track_id(track_id),
         track_context=track_context,
@@ -173,6 +177,7 @@ def get_data_for_tracks(
         initargs=(db_location,),
     ) as pool:
         return list(
+            el for el in
             tqdm(
                 (
                     track
@@ -193,6 +198,7 @@ def get_data_for_tracks(
                 unit="track",
                 total=len(track_ids),
             )
+            if el is not None
         )
 
 

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -67,9 +67,12 @@ def get_track_info(
 
     track_source = track_location
 
+    # When no virtual out dir is given, the XML should point to where the
+    # files actually land, so fall back to out_dir.
+    effective_virtual_out_dir = virtual_out_dir or out_dir
     if out_dir or out_format:
         track_location = change_track_location(
-            track_location, out_dir, out_format, export_semaphore, virtual_out_dir
+            track_location, out_dir, out_format, export_semaphore, effective_virtual_out_dir
         )
     if track_location.endswith(".ogg"):
         temp_path = Path.home().absolute() / "temp"
@@ -80,6 +83,7 @@ def get_track_info(
             str(temp_path),
             "mp3",
             export_semaphore,
+            str(temp_path),
         )
         print(f"New track created at: {track_location}")
 

--- a/handlers/sql.py
+++ b/handlers/sql.py
@@ -50,11 +50,11 @@ def get_mixxx_db_location(custom_db_location: str | None) -> str:
     if os.getenv("LOCALAPPDATA"):
         return f"{os.getenv('LOCALAPPDATA')}\\Mixxx\\mixxxdb.sqlite"
     # MacOS
-    if path.exists(r"~/Library/Application Support/Mixxx"):
-        return r"~/Library/Application Support/Mixxx/mixxxdb.sqlite"
+    if path.exists(path.expanduser(r"~/Library/Application Support/Mixxx")):
+        return path.expanduser(r"~/Library/Application Support/Mixxx/mixxxdb.sqlite")
     # Linux
-    if path.exists(r"~/.mixxx"):
-        return r"~/.mixxx/mixxxdb.sqlite"
+    if path.exists(path.expanduser(r"~/.mixxx")):
+        return path.expanduser(r"~/.mixxx/mixxxdb.sqlite")
 
 
 def set_db_location(db_location: str) -> None:

--- a/handlers/sql.py
+++ b/handlers/sql.py
@@ -50,19 +50,13 @@ def get_mixxx_db_location(custom_db_location: str | None) -> str:
     if os.getenv("LOCALAPPDATA"):
         return f"{os.getenv('LOCALAPPDATA')}\\Mixxx\\mixxxdb.sqlite"
     # MacOS
-    if path.exists(r"~/Library/Application Support/Mixxx"):
-        return r"~/Library/Application Support/Mixxx/mixxxdb.sqlite"
-    if path.exists(
-        path.expanduser(
-            r"~/Library/Containers/org.mixxx.mixxx/Data/Library/Application Support/Mixxx/mixxxdb.sqlite"
-        )
-    ):
-        return path.expanduser(
-            r"~/Library/Containers/org.mixxx.mixxx/Data/Library/Application Support/Mixxx/mixxxdb.sqlite"
-        )
+    if path.exists(path.expanduser(r"~/Library/Application Support/Mixxx")):
+        return path.expanduser(r"~/Library/Application Support/Mixxx/mixxxdb.sqlite")
+    if path.exists(path.expanduser(r"~/Library/Containers/org.mixxx.mixxx/Data/Library/Application Support/Mixxx")):
+        return path.expanduser(r"~/Library/Containers/org.mixxx.mixxx/Data/Library/Application Support/Mixxx/mixxxdb.sqlite")
     # Linux
-    if path.exists(r"~/.mixxx"):
-        return r"~/.mixxx/mixxxdb.sqlite"
+    if path.exists(path.expanduser(r"~/.mixxx")):
+        return path.expanduser(r"~/.mixxx/mixxxdb.sqlite")
 
     raise Exception("Mixxx DB not found")
 

--- a/handlers/transcode.py
+++ b/handlers/transcode.py
@@ -21,7 +21,11 @@ def get_bitrate_from_format(out_format: str) -> str | None:
 
 
 def transcode_track(
-    track_path: Path, out_path: Path, out_format: str, export_semaphore: Semaphore
+    track_path: Path,
+    out_path: Path,
+    out_format: str,
+    export_semaphore: Semaphore,
+    virtual_out_path: Path,
 ) -> str:
     with export_semaphore:
         segment = AudioSegment.from_file(track_path, format=track_path.suffix[1:])
@@ -33,7 +37,7 @@ def transcode_track(
             bitrate=get_bitrate_from_format(out_format),
             tags=tags.as_dict(),
         )
-    return str(new_file)
+    return str(virtual_out_path.joinpath(f"{track_path.stem}.{out_format}"))
 
 
 def change_track_location(
@@ -41,12 +45,14 @@ def change_track_location(
     out_dir: str,
     out_format: str | None,
     export_semaphore: Semaphore,
+    virtual_out_dir: str,
 ) -> str:
     track_path = Path(track_location)
     out_dir_path = Path(out_dir)
+    virtual_out_path = Path(virtual_out_dir)
     if out_format:
-        return transcode_track(track_path, out_dir_path, out_format, export_semaphore)
+        return transcode_track(track_path, out_dir_path, out_format, export_semaphore, virtual_out_path)
     else:
         out_file_path = out_dir_path.joinpath(track_path.name)
         shutil.copy2(track_path, out_file_path)
-        return str(out_file_path)
+        return str(virtual_out_path.joinpath(track_path.name))

--- a/handlers/transcode.py
+++ b/handlers/transcode.py
@@ -15,9 +15,16 @@ BITRATE_MAP = {
     "aac": "256k",
 }
 
+FORMAT_MAP = {
+    "opus": "ogg"
+}
+
 
 def get_bitrate_from_format(out_format: str) -> str | None:
     return BITRATE_MAP.get(out_format.lower())
+
+def get_format_from_suffix(suffix: str) -> str:
+    return FORMAT_MAP.get(suffix) or suffix
 
 
 def transcode_track(
@@ -28,7 +35,7 @@ def transcode_track(
     virtual_out_path: Path,
 ) -> str:
     with export_semaphore:
-        segment = AudioSegment.from_file(track_path, format=track_path.suffix[1:])
+        segment = AudioSegment.from_file(track_path, format=get_format_from_suffix(track_path.suffix[1:]))
         tags = TinyTag.get(track_path)
         new_file = out_path.joinpath(f"{track_path.stem}.{out_format}")
         segment.export(

--- a/handlers/transcode.py
+++ b/handlers/transcode.py
@@ -14,9 +14,16 @@ BITRATE_MAP = {
     "aac": "256k",
 }
 
+FORMAT_MAP = {
+    "opus": "ogg"
+}
+
 
 def get_bitrate_from_format(out_format: str) -> str | None:
     return BITRATE_MAP.get(out_format.lower())
+
+def get_format_from_suffix(suffix: str) -> str:
+    return FORMAT_MAP.get(suffix) or suffix
 
 
 def transcode_track(
@@ -39,7 +46,7 @@ def transcode_track(
         in_format = "aiff"
 
     with export_semaphore:
-        segment = AudioSegment.from_file(track_path, format=in_format)
+        segment = AudioSegment.from_file(track_path, format=get_format_from_suffix(in_format))
         tags = TinyTag.get(track_path)
 
         segment.export(

--- a/handlers/transcode.py
+++ b/handlers/transcode.py
@@ -35,12 +35,14 @@ def transcode_track(
 ) -> str:
     in_format = track_path.suffix[1:]
     new_file = out_path.joinpath(f"{track_path.stem}.{out_format}")
+    virtual_file = virtual_out_path.joinpath(f"{track_path.stem}.{out_format}")
 
     if new_file.exists():
-        return str(new_file)
+        return str(virtual_file)
 
     if in_format == out_format:
-        return str(track_path.copy(new_file))
+        shutil.copy2(track_path, new_file)
+        return str(virtual_file)
 
     if in_format == "aif":
         in_format = "aiff"

--- a/handlers/transcode.py
+++ b/handlers/transcode.py
@@ -20,7 +20,11 @@ def get_bitrate_from_format(out_format: str) -> str | None:
 
 
 def transcode_track(
-    track_path: Path, out_path: Path, out_format: str, export_semaphore: Semaphore
+    track_path: Path,
+    out_path: Path,
+    out_format: str,
+    export_semaphore: Semaphore,
+    virtual_out_path: Path,
 ) -> str:
     in_format = track_path.suffix[1:]
     new_file = out_path.joinpath(f"{track_path.stem}.{out_format}")
@@ -44,7 +48,7 @@ def transcode_track(
             bitrate=get_bitrate_from_format(out_format),
             tags=tags.as_dict(),
         )
-    return str(new_file)
+    return str(virtual_out_path.joinpath(f"{track_path.stem}.{out_format}"))
 
 
 def change_track_location(
@@ -52,12 +56,14 @@ def change_track_location(
     out_dir: str,
     out_format: str | None,
     export_semaphore: Semaphore,
+    virtual_out_dir: str,
 ) -> str:
     track_path = Path(track_location)
     out_dir_path = Path(out_dir)
+    virtual_out_path = Path(virtual_out_dir)
     if out_format:
-        return transcode_track(track_path, out_dir_path, out_format, export_semaphore)
+        return transcode_track(track_path, out_dir_path, out_format, export_semaphore, virtual_out_path)
     else:
         out_file_path = out_dir_path.joinpath(track_path.name)
         shutil.copy2(track_path, out_file_path)
-        return str(out_file_path)
+        return str(virtual_out_path.joinpath(track_path.name))

--- a/list_file.py
+++ b/list_file.py
@@ -1,0 +1,75 @@
+"""Read and write collection list files.
+
+A list file lets the user pre-select which crates and playlists to export.
+Lines starting with ``#`` (after optional whitespace) are comments and are
+ignored. Every other non-empty line must follow the form::
+
+    <playlist|crate>: <name>
+
+where ``<name>`` is the crate/playlist name exactly as it appears in Mixxx.
+Non-commented lines are exported non-interactively when ``--list-file`` is
+passed to the script.
+"""
+from pathlib import Path
+
+from models import CollectionType
+
+# Singular label used per collection type inside the list file.
+LIST_TYPE_LABEL: dict[CollectionType, str] = {
+    "playlists": "playlist",
+    "crates": "crate",
+}
+
+LIST_FILE_HEADER = [
+    "# MixxxToRekordbox collection list",
+    "# Uncomment a line (remove the leading '# ') to export that collection.",
+    "# Lines starting with '#' are ignored.",
+    "# Format: <playlist|crate>: <name>",
+    "",
+]
+
+
+def parse_list_file(path: str) -> dict[CollectionType, set[str]]:
+    """Parse a list file and return the selected names per collection type.
+
+    Only non-commented lines are returned. Unknown type labels are ignored.
+    """
+    selected: dict[CollectionType, set[str]] = {"playlists": set(), "crates": set()}
+    with open(path, "r", encoding="utf-8") as fd:
+        for raw_line in fd:
+            line = raw_line.rstrip("\n")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            # Format: "<type>: <name>". Split on the first ": " so that names
+            # containing ": " are preserved.
+            if ": " not in stripped:
+                continue
+            type_str, name = stripped.split(": ", 1)
+            if type_str == "playlist":
+                selected["playlists"].add(name)
+            elif type_str == "crate":
+                selected["crates"].add(name)
+    return selected
+
+
+def write_list_file(
+    path: str,
+    collections: dict[CollectionType, list[tuple[str, str]]],
+) -> None:
+    """Write all given collections to a list file, commented out.
+
+    ``collections`` maps a collection type to a list of ``(id, name)`` tuples
+    as returned by :func:`handlers.sql.get_collections`.
+    """
+    lines = list(LIST_FILE_HEADER)
+    for ctype in ("playlists", "crates"):
+        items = collections.get(ctype, [])
+        if not items:
+            continue
+        label = LIST_TYPE_LABEL[ctype]
+        lines.append(f"# {ctype}:")
+        for _id, name in items:
+            lines.append(f"# {label}: {name}")
+        lines.append("")
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/main.py
+++ b/main.py
@@ -11,6 +11,9 @@ arg_parser.add_argument(
     "--out-dir", type=str, help="Outputs tracks to a new directory."
 )
 arg_parser.add_argument(
+    "--virtual-out-dir", type=str, help="Rekordbox will find tracks in this location, requires --out-dir to be set"
+)
+arg_parser.add_argument(
     "--format",
     type=str,
     help="Change the file format of the tracks, requires --out-dir to be set.",
@@ -41,6 +44,7 @@ def main() -> None:
     args = arg_parser.parse_args()
     out_format: str | None = args.format
     out_dir: str | None = args.out_dir
+    virtual_out_dir: str | None = args.virtual_out_dir
     export_all: bool = args.export_all
     mixxx_db_location: str | None = args.mixxx_db_location
     key_type: KeyType = args.key_type or KeyType.LANCELOT
@@ -48,7 +52,7 @@ def main() -> None:
     collection_type: CollectionType = "crates" if use_crates else "playlists"
 
     export_to_rekordbox_xml(
-        out_format, out_dir, export_all, mixxx_db_location, key_type, collection_type
+        out_format, out_dir, export_all, mixxx_db_location, key_type, collection_type, virtual_out_dir
     )
 
 

--- a/main.py
+++ b/main.py
@@ -33,10 +33,54 @@ arg_parser.add_argument(
     help=f"Specify a key type to export: {[kt.value for kt in KeyType]}, defaults to {KeyType.LANCELOT}",
 )
 arg_parser.add_argument(
+    "--playlists",
+    action="store_true",
+    help="Export playlists. If neither --playlists nor --crates is given, playlists are exported by default.",
+)
+arg_parser.add_argument(
+    "--crates",
+    action="store_true",
+    help="Export crates. Combine with --playlists to export both in a single run.",
+)
+arg_parser.add_argument(
     "-c",
     "--use-crates",
     action="store_true",
-    help="Source the tracks from crates instead of playlists, XML output will still be playlists.",
+    help="Equivalent to --crates. Kept for backwards compatibility.",
+)
+arg_parser.add_argument(
+    "--playlists-prefix",
+    type=str,
+    default="",
+    help="Prefix prepended to every exported playlist name in the Rekordbox XML.",
+)
+arg_parser.add_argument(
+    "--playlists-suffix",
+    type=str,
+    default="",
+    help="Suffix appended to every exported playlist name in the Rekordbox XML.",
+)
+arg_parser.add_argument(
+    "--crates-prefix",
+    type=str,
+    default="",
+    help="Prefix prepended to every exported crate name in the Rekordbox XML (crates are exported as playlists).",
+)
+arg_parser.add_argument(
+    "--crates-suffix",
+    type=str,
+    default="",
+    help="Suffix appended to every exported crate name in the Rekordbox XML (crates are exported as playlists).",
+)
+arg_parser.add_argument(
+    "--list-file",
+    type=str,
+    help="Path to a list file. Non-commented entries are exported non-interactively; all other collections are skipped.",
+)
+arg_parser.add_argument(
+    "--generate-list-file",
+    type=str,
+    help="Write a list file of all available crates/playlists (commented out) to the given path and exit. Edit the file and pass it back via --list-file to pre-select collections.",
 )
 
 
@@ -48,11 +92,45 @@ def main() -> None:
     export_all: bool = args.export_all
     mixxx_db_location: str | None = args.mixxx_db_location
     key_type: KeyType = args.key_type or KeyType.LANCELOT
-    use_crates: bool = args.use_crates
-    collection_type: CollectionType = "crates" if use_crates else "playlists"
+
+    include_playlists: bool = args.playlists
+    include_crates: bool = args.crates or args.use_crates
+
+    collection_types: list[CollectionType] = []
+    if include_playlists:
+        collection_types.append("playlists")
+    if include_crates:
+        collection_types.append("crates")
+    if not collection_types:
+        # When generating a list file with no explicit collection type, list
+        # both so the user can choose from everything available. Otherwise
+        # default to playlists for backwards compatibility.
+        if args.generate_list_file:
+            collection_types = ["playlists", "crates"]
+        else:
+            collection_types = ["playlists"]
+
+    prefixes: dict[CollectionType, str] = {
+        "playlists": args.playlists_prefix,
+        "crates": args.crates_prefix,
+    }
+    suffixes: dict[CollectionType, str] = {
+        "playlists": args.playlists_suffix,
+        "crates": args.crates_suffix,
+    }
 
     export_to_rekordbox_xml(
-        out_format, out_dir, export_all, mixxx_db_location, key_type, collection_type, virtual_out_dir
+        out_format,
+        out_dir,
+        export_all,
+        mixxx_db_location,
+        key_type,
+        collection_types,
+        virtual_out_dir,
+        prefixes,
+        suffixes,
+        args.list_file,
+        args.generate_list_file,
     )
 
 

--- a/models.py
+++ b/models.py
@@ -201,6 +201,7 @@ class TrackContext:
     genre: str
     duration: int
     location: str
+    source: str
     samplerate: int
     channels: int
     bpm: float

--- a/models.py
+++ b/models.py
@@ -274,7 +274,7 @@ class ExportedTrack:
     ):
         self.id = id
         self.track_context = track_context
-        self.offset_sec = get_offset_sec(self.track_context.location)
+        self.offset_sec = get_offset_sec(self.track_context.location, self.track_context.source)
         if beat_grid:
             self._add_beat_grid(beat_grid)
         self.cue_points = []

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -73,7 +73,9 @@ def check_mp3_decoder_value(mp3_decoder: str) -> None:
         )
 
 
-def get_offset_ms(track_path: str | Path, mp3_decoder: Mp3Decoder) -> int:
+def get_offset_ms(
+    track_path: str | Path, source_path: str | Path, mp3_decoder: Mp3Decoder
+) -> int:
     path = Path(track_path)
     if path.suffix == ".m4a":
         return 48
@@ -87,8 +89,10 @@ def get_offset_ms(track_path: str | Path, mp3_decoder: Mp3Decoder) -> int:
     return 0
 
 
-def get_offset_sec(track_path: str | Path, mp3_decoder: Mp3Decoder = "MAD") -> float:
-    return get_offset_ms(track_path, mp3_decoder) / 1000.0
+def get_offset_sec(
+    track_path: str | Path, source_path: str | Path, mp3_decoder: Mp3Decoder = "MAD"
+) -> float:
+    return get_offset_ms(track_path, source_path, mp3_decoder) / 1000.0
 
 
 def flush_offset_errors() -> None:

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -76,16 +76,21 @@ def check_mp3_decoder_value(mp3_decoder: str) -> None:
 def get_offset_ms(
     track_path: str | Path, source_path: str | Path, mp3_decoder: Mp3Decoder
 ) -> int:
-    path = Path(track_path)
-    if path.suffix == ".m4a":
+    in_format = Path(source_path).suffix
+    out_format = Path(track_path).suffix
+    if out_format == ".m4a":
         return 48
-    if path.suffix == ".mp3":
+    elif in_format == out_format == ".mp3":
         try:
             audiofile = eyed3.load(track_path)
             return get_offset_mp3(audiofile, mp3_decoder)
         except Exception as ex:
             OFFSET_ERROR_MESSAGES.append(f"{track_path}: {ex}")
             return 0
+    elif in_format == ".flac" and out_format == ".wav":
+        return 0
+    elif in_format == ".flac" and out_format == ".mp3":
+        return 0
     return 0
 
 

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -89,9 +89,9 @@ def get_offset_ms(
             OFFSET_ERROR_MESSAGES.append(f"{track_path}: {ex}")
             return 0
     elif in_format == ".flac" and out_format == ".wav":
-        return 0
+        return 26
     elif in_format == ".flac" and out_format == ".mp3":
-        return 0
+        return 26
 
     print(
         f"Warning: transcoding from {in_format} to {out_format} is experimental and may result in misaligned cues",

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -3,6 +3,7 @@
 from logging import ERROR
 from pathlib import Path
 from typing import Literal
+import sys
 
 import eyed3.mp3.headers  # type: ignore
 
@@ -91,6 +92,12 @@ def get_offset_ms(
         return 0
     elif in_format == ".flac" and out_format == ".mp3":
         return 0
+
+    print(
+        f"Warning: transcoding from {in_format} to {out_format} is experimental and may result in misaligned cues",
+        file=sys.stderr
+    )
+
     return 0
 
 

--- a/rekordbox_gen.py
+++ b/rekordbox_gen.py
@@ -76,16 +76,21 @@ def create_playlist_track_elm(track_id: str) -> etree.Element:
     return E.TRACK(Key=track_id)
 
 
+def create_root_element() -> etree.Element:
+    """Return a minimal valid DJ_PLAYLISTS root element."""
+    return E.DJ_PLAYLISTS(
+        E.PRODUCT(Name="rekordbox", Version="6.5.2", Company="AlphaTheta"),
+        Version="1.0.0",
+    )
+
+
 def generate_xml(
     tracks: list[ExportedTrack],
     playlist_name,
     dj_playlist: etree.Element | None,
 ) -> etree.Element:
     if dj_playlist is None:
-        dj_playlist = E.DJ_PLAYLISTS(
-            E.PRODUCT(Name="rekordbox", Version="6.5.2", Company="AlphaTheta"),
-            Version="1.0.0",
-        )
+        dj_playlist = create_root_element()
 
     collection_elm = find_or_create_element(1, "COLLECTION", dj_playlist)
 


### PR DESCRIPTION
Please excuse the single PR; review commits as if they were distinct PRs, if you will:

- First commit fixes DB discovery on linux (and presumably MacOS as well)
- Second commit fixes crash, when trying to read a playlist with a missing entry from Mixxx DB.
- Third commit adds `--virtual-output-dir` option
- Fourth commit adds opus file support
- Fifth commit is just some build harness