### PR TITLE
Add export for Loop Hot Cues and Labels

### DIFF
--- a/handlers/export.py
+++ b/handlers/export.py
@@ -82,16 +82,22 @@ def get_cue_points(
 ) -> list[CuePoint]:
     return [
         CuePoint(
-            1,
+            cue_type,
             cue_index,
             mixxx_cuepos_to_ms(
                 int(cue_position),
                 samplerate,
                 channels,
             ),
+            mixxx_cuepos_to_ms(
+                int(cue_position) + int(length),
+                samplerate,
+                channels,
+            ),
             CueColour(hex(color)),
+            label,
         )
-        for (cue_index, cue_position, color) in sql_handlers.get_cue_points(track_id)
+        for (cue_index, cue_position, cue_type, length, color, label) in sql_handlers.get_cue_points(track_id)
     ]
 
 

--- a/handlers/sql.py
+++ b/handlers/sql.py
@@ -38,7 +38,7 @@ TRACK_INFO_QUERY = """
                     id = :id
                 """
 
-CUE_POINT_QUERY = "SELECT hotcue,position,color from cues WHERE cues.type = 1 and cues.hotcue >= 0 and cues.track_id = :id"
+CUE_POINT_QUERY = "SELECT hotcue,position,type,length,color,label from cues WHERE (cues.type = 1 or cues.type = 4) and cues.hotcue >= 0 and cues.track_id = :id"
 
 global _db_location
 

--- a/models.py
+++ b/models.py
@@ -231,9 +231,30 @@ class CuePoint(dict):
     cue_type: hex
     cue_index: int
     cue_position: float
+    cue_end: float
     cue_color: CueColour
-    cue_text: str = ""
+    cue_text: str
 
+    def __init__(
+        self,
+        cue_type: hex,
+        cue_index: int,
+        cue_position: float,
+        cue_end: float,
+        cue_color: CueColour,
+        cue_text: str = "",
+    ):
+        self.cue_index = cue_index
+        self.cue_position = cue_position
+        self.cue_end = cue_end
+        self.cue_color = cue_color
+        self.cue_text = cue_text
+
+        if (cue_type == 1):  # Regular cues are 0 in RB and 1 in Mixxx
+            self.cue_type = 0
+        else:
+            self.cue_type = cue_type
+       
 
 @dataclass
 class ExportedTrack:
@@ -271,4 +292,8 @@ class ExportedTrack:
             ]
         cue_point.cue_position += self.offset_sec
         cue_point.cue_position = max(0, cue_point.cue_position)
+        if cue_point.cue_type == 4: # Loop Hot Cue
+            cue_point.cue_end += self.offset_sec
+            cue_point.cue_end = max(0, cue_point.cue_end)
+
         self.cue_points.append(cue_point)

--- a/rekordbox_gen.py
+++ b/rekordbox_gen.py
@@ -1,6 +1,7 @@
+import platform
+
 from lxml import etree
 from lxml.builder import E
-import platform
 
 from models import ExportedTrack
 
@@ -61,10 +62,11 @@ def create_track_elm(track: ExportedTrack) -> etree.Element:
             Name=cue_point.cue_text.rstrip("\x00"),
             Num=str(cue_point.cue_index),
             Start=str(cue_point.cue_position / 1000),
+            End=str(cue_point.cue_end / 1000) if cue_point.cue_type == 4 else "0",
             Red=str(cue_point.cue_color.r_int),
             Green=str(cue_point.cue_color.g_int),
             Blue=str(cue_point.cue_color.b_int),
-            Type="0",
+            Type=str(cue_point.cue_type),
         )
         track_elm.append(cue_elm)
     return track_elm


### PR DESCRIPTION
Well, i sat down and did it myself lmao

This PR adds support for exporting Loop Hot Cues and Hot Cue Labels to RB. Fixes #2.

- The CuePoint dataclass was changed to store the Loop End timestamp and Hot Cue label.
- Changed CUE_POINT_QUERY to also obtain Loop Hot Cues (type 4)
- Removed hardcoded Type 0 on the XML generation

<img width="538" height="392" alt="ksnip_20260204-193414" src="https://github.com/user-attachments/assets/2fdca68f-6a55-4a62-b9b0-a9dc16702ae6" />
<img width="1746" height="262" alt="ksnip_20260204-210643" src="https://github.com/user-attachments/assets/1b4c5d90-1751-4598-9ea2-eb439010f2ef" />
