### PR TITLE
Fix missing track files

### DIFF
--- a/handlers/sql.py
+++ b/handlers/sql.py
@@ -33,7 +33,7 @@ TRACK_INFO_QUERY = """
                     library l
                 INNER JOIN
                     track_locations tl
-                USING (id)
+                ON l.location = tl.id
                 WHERE
                     id = :id
                 """


### PR DESCRIPTION
The query in `get_track_info(..)` occasionally fails and returns `None` when the track file location has changed/moved. 

In this case, it seems like a new row in `track_locations` is created, and the id of the new row is updated in `library.location`, and the old row with id matching the track id is deleted. When this happens, there is no longer a row in `track_locations` with the same id original track's id.