### PR TITLE
Correct offset when transcoding

### DIFF
--- a/handlers/export.py
+++ b/handlers/export.py
@@ -64,6 +64,7 @@ def get_track_info(
         print(f"File not found at {track_location}")
         return None
 
+    track_source = track_location
     if out_dir or out_format:
         track_location = change_track_location(
             track_location, out_dir, out_format, export_semaphore
@@ -91,6 +92,7 @@ def get_track_info(
         genre=genre or "",
         bpm=float(bpm) or 0.0,
         location=track_location,
+        source=track_source,
         key=key_type.get_key(key_id),
         rating=RATING_MAP[rating],
         colour=colour,

--- a/models.py
+++ b/models.py
@@ -201,6 +201,7 @@ class TrackContext:
     genre: str
     duration: int
     location: str
+    source: str
     samplerate: int
     channels: int
     bpm: float

--- a/models.py
+++ b/models.py
@@ -274,7 +274,7 @@ class ExportedTrack:
     ):
         self.id = id
         self.track_context = track_context
-        self.offset_sec = get_offset_sec(self.track_context.location)
+        self.offset_sec = get_offset_sec(self.track_context.location, self.track_context.source)
         if beat_grid:
             self._add_beat_grid(beat_grid)
         self.cue_points = []

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -73,7 +73,9 @@ def check_mp3_decoder_value(mp3_decoder: str) -> None:
         )
 
 
-def get_offset_ms(track_path: str | Path, mp3_decoder: Mp3Decoder) -> int:
+def get_offset_ms(
+    track_path: str | Path, source_path: str | Path, mp3_decoder: Mp3Decoder
+) -> int:
     path = Path(track_path)
     if path.suffix == ".m4a":
         return 48
@@ -87,8 +89,10 @@ def get_offset_ms(track_path: str | Path, mp3_decoder: Mp3Decoder) -> int:
     return 0
 
 
-def get_offset_sec(track_path: str | Path, mp3_decoder: Mp3Decoder = "MAD") -> float:
-    return get_offset_ms(track_path, mp3_decoder) / 1000.0
+def get_offset_sec(
+    track_path: str | Path, source_path: str | Path, mp3_decoder: Mp3Decoder = "MAD"
+) -> float:
+    return get_offset_ms(track_path, source_path, mp3_decoder) / 1000.0
 
 
 def flush_offset_errors() -> None:

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -76,16 +76,21 @@ def check_mp3_decoder_value(mp3_decoder: str) -> None:
 def get_offset_ms(
     track_path: str | Path, source_path: str | Path, mp3_decoder: Mp3Decoder
 ) -> int:
-    path = Path(track_path)
-    if path.suffix == ".m4a":
+    in_format = Path(source_path).suffix
+    out_format = Path(track_path).suffix
+    if out_format == ".m4a":
         return 48
-    if path.suffix == ".mp3":
+    elif in_format == out_format == ".mp3":
         try:
             audiofile = eyed3.load(track_path)
             return get_offset_mp3(audiofile, mp3_decoder)
         except Exception as ex:
             OFFSET_ERROR_MESSAGES.append(f"{track_path}: {ex}")
             return 0
+    elif in_format == ".flac" and out_format == ".wav":
+        return 0
+    elif in_format == ".flac" and out_format == ".mp3":
+        return 0
     return 0
 
 

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -89,9 +89,9 @@ def get_offset_ms(
             OFFSET_ERROR_MESSAGES.append(f"{track_path}: {ex}")
             return 0
     elif in_format == ".flac" and out_format == ".wav":
-        return 0
+        return 26
     elif in_format == ".flac" and out_format == ".mp3":
-        return 0
+        return 26
 
     print(
         f"Warning: transcoding from {in_format} to {out_format} is experimental and may result in misaligned cues",

--- a/offset_handlers.py
+++ b/offset_handlers.py
@@ -3,6 +3,7 @@
 from logging import ERROR
 from pathlib import Path
 from typing import Literal
+import sys
 
 import eyed3.mp3.headers  # type: ignore
 
@@ -91,6 +92,12 @@ def get_offset_ms(
         return 0
     elif in_format == ".flac" and out_format == ".mp3":
         return 0
+
+    print(
+        f"Warning: transcoding from {in_format} to {out_format} is experimental and may result in misaligned cues",
+        file=sys.stderr
+    )
+
     return 0
 
 


### PR DESCRIPTION
See #5. According to https://github.com/mixxxdj/mixxx/pull/2119 and https://github.com/digital-dj-tools/dj-data-converter/issues/3, encoders and file formats on both Rekordbox and Mixxx can affect the offset. Currently this script does not account for changes in offset when transcoding files. This PR adds the file source (pre-transcoding) as an input to the offset calculation function, so that this may be taken into account. Measuring offset for every possible combination of filetype and encoder would be too much work for me, so I have added a warning for file transcodings which haven't been measured. I have measured flac->mp3 and flac->wav on Windows 11, both of which showed an offset of 26ms for all 20 files. Please play around with it a bit before merging, I have no idea if this value is correct across platforms and flac sources.